### PR TITLE
Fixed compilation on my linux box.

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -12,12 +12,13 @@ set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/../cmake/Modules
 project(edith)
 
 find_package(Protobuf REQUIRED)
-include_directories(${PROTOBUF_INCLUDE_DIR})
+include_directories(${PROTOBUF_INCLUDE_DIRS})
 
 find_package(Snappy)
-include_directories(${SNAPPY_INCLUDE_DIRS})
+include_directories(${SNAPPY_INCLUDE_DIR})
 
 file(GLOB edith_PROTOS proto/*.proto)
+set(PROTOBUF_IMPORT_DIRS ${PROTOBUF_INCLUDE_DIRS})
 PROTOBUF_GENERATE_CPP(PROTO_SRCS PROTO_HDRS ${edith_PROTOS})
 include_directories(${CMAKE_CURRENT_BINARY_DIR})
 


### PR DESCRIPTION
How did this ever compile? It previously wasn't adding the include directories for neither protobuf nor snappy due to the typo in the variable name.

I have also added the protobuf include dir as an import dir, as the distros I tried do put "descriptor.proto" there, which is needed by protoc.
